### PR TITLE
Automatically clean up CartesiMachine resources with FinalizationRegistry

### DIFF
--- a/.changeset/petite-bears-wish.md
+++ b/.changeset/petite-bears-wish.md
@@ -1,0 +1,5 @@
+---
+"@tuler/node-cartesi-machine": minor
+---
+
+remove the exposed delete method, and use a finalizer to automatically call cm_delete on garbage collected machines

--- a/docs/pages/api/cartesi-machine.mdx
+++ b/docs/pages/api/cartesi-machine.mdx
@@ -14,7 +14,6 @@ export interface CartesiMachine {
     cloneEmpty(): CartesiMachine;
     store(dir: string): void;
     destroy(): void;
-    delete(): void;
     
     //// Configuration
     getDefaultConfig(): MachineConfig;
@@ -137,14 +136,6 @@ Destroys the current machine instance and removes it from the object. Does not d
 
 ```ts
 destroy(): void;
-```
-
-## delete
-
-Deletes the machine object. If the object is not empty, destroys the instance first. The object must not be used after this call.
-
-```ts
-delete(): void;
 ```
 
 ## getDefaultConfig

--- a/docs/pages/local.mdx
+++ b/docs/pages/local.mdx
@@ -126,58 +126,13 @@ const hash = machine.getRootHash(); // [!code focus]
 console.log(hash); // [!code focus]
 ```
 
-## Cleaning up
-
-Finally, after being done using the machine the resources allocated can be freed by calling the `delete()` method:
-
-```ts twoslash
-import { BreakReason, create } from "@tuler/node-cartesi-machine";
-
-// create a basic machine that print Hello world
-const machine = create({
-    ram: {
-        length: 0x8000000, // 128MB of RAM
-        image_filename: "linux.bin",
-    },
-    flash_drive: [
-        {
-            image_filename: "rootfs.ext2",
-        },
-    ],
-    dtb: {
-        entrypoint: "echo Hello world!",
-    },
-});
-
-// run the machine until it yields or halts (default is MAX_MCYCLE)
-const reason = machine.run();
-switch (reason) {
-    case BreakReason.YieldedManually:
-        console.log("Machine yielded manually");
-        break;
-    case BreakReason.Halted:
-        console.log("Machine halted");
-        break;
-    default:
-        console.log(`Machine halted: ${reason}`);
-}
-console.log(reason);
-
-// calculate machine root hash
-const hash = machine.getRootHash();
-console.log(hash);
-
-// destroy the machine // [!code focus]
-machine.delete(); // [!code focus]
-```
-
 The complete `CartesiMachine` API is available in the API section.
 
 ## Memory Management
 
-The API automatically handles memory management for machine objects.
-When you call `delete()` on a machine, it properly cleans up the underlying C resources.
-Always call `delete()` when you're done with a machine to prevent memory leaks.
+The API automatically handles memory management for machine objects. When a `machine` instance is garbage collected by Node.js, its underlying C resources are automatically cleaned up.
+
+However, you can also explicitly free the resources held by a machine object by calling its `destroy()` method. This is useful if you want to immediately release native resources without waiting for garbage collection.
 
 ## Thread Safety
 

--- a/docs/pages/remote.mdx
+++ b/docs/pages/remote.mdx
@@ -50,9 +50,6 @@ console.log(reason);
 // calculate machine root hash
 const hash = machine.getRootHash();
 console.log(hash);
-
-// destroy the machine
-machine.delete();
 ```
 
 What is happening under the hood is that we are spawning a child `cartesi-jsonrpc-machine` process, which hosts a local Cartesi machine, and expose a JSON-RPC server to control it.

--- a/docs/snippets/local.ts
+++ b/docs/snippets/local.ts
@@ -33,6 +33,3 @@ console.log(reason);
 // calculate machine root hash
 const hash = machine.getRootHash();
 console.log(hash);
-
-// destroy the machine
-machine.delete();

--- a/docs/snippets/remote.ts
+++ b/docs/snippets/remote.ts
@@ -32,6 +32,3 @@ console.log(reason);
 // calculate machine root hash
 const hash = machine.getRootHash();
 console.log(hash);
-
-// destroy the machine
-machine.delete();

--- a/examples/cartesi-machine.ts
+++ b/examples/cartesi-machine.ts
@@ -73,10 +73,6 @@ async function basicMachineExample() {
         console.log("Storing machine...");
         machine.store("./machine-state");
         console.log("Machine stored successfully");
-
-        // Clean up
-        machine.delete();
-        console.log("Machine deleted");
     } catch (error) {
         console.error("Error:", error);
     }
@@ -117,10 +113,6 @@ async function memoryOperationsExample() {
             const word = machine.readWord(address + BigInt(i * 8));
             console.log(`Word ${i}: 0x${word.toString(16).padStart(16, "0")}`);
         }
-
-        // Clean up
-        machine.delete();
-        console.log("Memory operations completed");
     } catch (error) {
         console.error("Error:", error);
     }
@@ -172,10 +164,6 @@ async function registerOperationsExample() {
             const address = getRegAddress(reg);
             console.log(`${name} address: 0x${address.toString(16)}`);
         }
-
-        // Clean up
-        machine.delete();
-        console.log("Register operations completed");
     } catch (error) {
         console.error("Error:", error);
     }
@@ -227,10 +215,6 @@ async function merkleTreeExample() {
             "Dirty page maps:",
             areDirtyMapsValid ? "Valid" : "Invalid",
         );
-
-        // Clean up
-        machine.delete();
-        console.log("Merkle tree operations completed");
     } catch (error) {
         console.error("Error:", error);
     }
@@ -279,10 +263,6 @@ async function executionExample() {
         console.log("Resetting microarchitecture...");
         machine.resetUarch();
         console.log("Microarchitecture reset");
-
-        // Clean up
-        machine.delete();
-        console.log("Execution example completed");
     } catch (error) {
         console.error("Error:", error);
     }
@@ -301,7 +281,6 @@ async function errorHandlingExample() {
         try {
             const machine = create({ ram: { length: -1 } });
             console.log("Unexpected: Machine created successfully");
-            machine.delete();
         } catch (error) {
             console.log("Expected error caught:", (error as Error).message);
         }
@@ -327,11 +306,6 @@ async function errorHandlingExample() {
         } catch (error) {
             console.log("Expected error caught:", (error as Error).message);
         }
-
-        // Clean up
-        machine.delete();
-        emptyMachine.delete();
-        console.log("Error handling example completed");
     } catch (error) {
         console.error("Unexpected error:", error);
     }

--- a/src/cartesi-machine.ts
+++ b/src/cartesi-machine.ts
@@ -359,7 +359,6 @@ export interface CartesiMachine {
     ): void;
     verifyMerkleTree(): boolean;
     verifyDirtyPageMaps(): boolean;
-    delete(): void;
 }
 
 export function empty(): CartesiMachine {

--- a/src/node/cartesi-machine.ts
+++ b/src/node/cartesi-machine.ts
@@ -254,6 +254,12 @@ enum AccessLogTypeEnum {
 /**
  * High-level wrapper for the Cartesi Machine C API
  */
+const machineFinalizer = new FinalizationRegistry((machineHandle: any) => {
+    if (machineHandle) {
+        cm_delete(machineHandle);
+    }
+});
+
 export class NodeCartesiMachine {
     protected machine: any = null;
 
@@ -322,6 +328,7 @@ export class NodeCartesiMachine {
 
     constructor(machine: any) {
         this.machine = machine;
+        machineFinalizer.register(this, machine);
     }
 
     /**
@@ -995,13 +1002,5 @@ export class NodeCartesiMachine {
             throw MachineError.fromCode(error);
         }
         return result[0];
-    }
-
-    /**
-     * Deletes the machine object
-     */
-    delete(): void {
-        cm_delete(this.machine);
-        this.machine = null;
     }
 }

--- a/test/cartesi-machine.test.ts
+++ b/test/cartesi-machine.test.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import {
     type CartesiMachine,
     BreakReason,
@@ -27,18 +27,11 @@ describe("CartesiMachine", () => {
         machine = create(config);
     });
 
-    afterEach(() => {
-        if (machine) {
-            machine.delete();
-        }
-    });
-
     describe("Static Methods", () => {
         it("should create a new empty machine", () => {
             const emptyMachine = empty();
             expect(emptyMachine).toBeInstanceOf(NodeCartesiMachine);
             expect(emptyMachine.isEmpty()).toBe(true);
-            emptyMachine.delete();
         });
 
         it("should clone an empty machine", () => {
@@ -46,8 +39,6 @@ describe("CartesiMachine", () => {
             const cloned = original.cloneEmpty();
             expect(cloned).toBeInstanceOf(NodeCartesiMachine);
             expect(cloned.isEmpty()).toBe(true);
-            original.delete();
-            cloned.delete();
         });
 
         it("should get default configuration", () => {
@@ -104,7 +95,6 @@ describe("CartesiMachine", () => {
             expect(loadedMachine.isEmpty()).toBe(false);
 
             // Clean up
-            loadedMachine.delete();
             fs.rmSync(testDir, { recursive: true, force: true });
         });
     });
@@ -341,8 +331,6 @@ describe("CartesiMachine", () => {
             expect(() => {
                 emptyMachine.getRootHash();
             }).toThrow();
-
-            emptyMachine.delete();
         });
     });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
         "outDir": "dist",
         "strict": true,
         "skipLibCheck": true,
-        "target": "es2020",
+        "target": "es2021",
         "paths": {
             "@tuler/node-cartesi-machine": ["./src/index.ts"]
         }


### PR DESCRIPTION
### Summary

This PR modernizes resource management for CartesiMachine objects by leveraging JavaScript’s `FinalizationRegistry` to automatically free native resources when a machine object is garbage collected. Manual calls to `delete()` are no longer required or supported.

### Key Changes

- **Removed the `delete()` method** from the `CartesiMachine` interface and all implementations.
- **Added a `FinalizationRegistry`** in `NodeCartesiMachine` to call `cm_delete` automatically when a machine object is garbage collected.
- **Removed all calls to `delete()`** from:
  - Tests
  - Examples
  - Documentation snippets
  - User and API documentation
- **Updated documentation** to clarify that resource cleanup is now automatic and manual deletion is not needed.
- **Targeted Node.js 20+**: The code now assumes a modern Node.js environment where `FinalizationRegistry` is globally available.

### Motivation

Previously, users were required to manually call `delete()` to free native resources, which was error-prone and could lead to memory leaks if forgotten. With this change, resource management is automatic and robust, improving developer experience and reliability.

### Migration Notes

- **Manual cleanup is no longer necessary**: Simply let machine objects go out of scope; their resources will be freed automatically.
- **All documentation and examples** have been updated to remove references to `delete()`.

### Checklist

- [x] Remove `delete()` from all interfaces and implementations
- [x] Add `FinalizationRegistry`-based cleanup
- [x] Remove all usages of `delete()` in code, tests, and docs
- [x] Update documentation to reflect the new behavior
