### PR TITLE
stdout bug reproduction

### DIFF
--- a/.changeset/heavy-baboons-film.md
+++ b/.changeset/heavy-baboons-film.md
@@ -1,0 +1,5 @@
+---
+"@tuler/node-cartesi-machine": patch
+---
+
+Fixing stdout of remote machines

--- a/.changeset/young-buttons-like.md
+++ b/.changeset/young-buttons-like.md
@@ -1,0 +1,5 @@
+---
+"@tuler/node-cartesi-machine": minor
+---
+
+allow setCleanupCall chaining

--- a/examples/honeypot.ts
+++ b/examples/honeypot.ts
@@ -1,5 +1,6 @@
 import {
     BreakReason,
+    CleanupCall,
     CmioYieldReason,
     spawn,
 } from "@tuler/node-cartesi-machine";
@@ -57,7 +58,7 @@ if (!fs.existsSync(snapshotPath)) {
 }
 
 // load honeypot mainnet machine
-const machine = spawn().load(snapshotPath);
+const machine = spawn().setCleanupCall(CleanupCall.Shutdown).load(snapshotPath);
 
 // send deposit
 machine.sendCmioResponse(
@@ -126,3 +127,5 @@ while (breakReason !== BreakReason.YieldedManually) {
     breakReason = machine.run();
 }
 console.log(machine.receiveCmioRequest());
+
+machine.shutdown();

--- a/examples/honeypot.ts
+++ b/examples/honeypot.ts
@@ -1,7 +1,7 @@
 import {
     BreakReason,
     CmioYieldReason,
-    load,
+    spawn,
 } from "@tuler/node-cartesi-machine";
 import fs from "node:fs";
 import { encodeFunctionData, encodePacked, hexToBytes, parseUnits } from "viem";
@@ -57,7 +57,7 @@ if (!fs.existsSync(snapshotPath)) {
 }
 
 // load honeypot mainnet machine
-const machine = load(snapshotPath);
+const machine = spawn().load(snapshotPath);
 
 // send deposit
 machine.sendCmioResponse(

--- a/src/node/remote-cartesi-machine.ts
+++ b/src/node/remote-cartesi-machine.ts
@@ -221,11 +221,12 @@ export class NodeRemoteCartesiMachine extends NodeCartesiMachine {
         return msPtr[0];
     }
 
-    setCleanupCall(call: CleanupCall): void {
+    setCleanupCall(call: CleanupCall): NodeRemoteCartesiMachine {
         const result = cm_jsonrpc_set_cleanup_call(this.machine, call);
         if (result !== ErrorCode.Ok) {
             throw MachineError.fromCode(result);
         }
+        return this;
     }
 
     getCleanupCall(): CleanupCall {

--- a/src/remote-cartesi-machine.ts
+++ b/src/remote-cartesi-machine.ts
@@ -24,7 +24,7 @@ export interface RemoteCartesiMachine extends CartesiMachine {
     emancipate(): void;
     setTimeout(ms: number): void;
     getTimeout(): number;
-    setCleanupCall(call: CleanupCall): void;
+    setCleanupCall(call: CleanupCall): RemoteCartesiMachine;
     getCleanupCall(): CleanupCall;
     getServerVersion(): string;
     delayNextRequest(ms: number): void;


### PR DESCRIPTION
This is a reproduction of the fact that when using a remote machine, spawned by the parent process, the stdout from inside the machine does not output to the parent process stdout (while when using local machine it does).

The following is the stdout of execution in both cases, highlighting the suppressed stdout.
```diff
$ tsx examples/honeypot.ts
1. deposit
-[dapp] successful deposit
         { cmd: 0, reason: 4, data: <Buffer 00> }
{
  cmd: 1,
  reason: 1,
  data: <Buffer 0a 16 29 46 e5 61 58 ba c0 67 3e 6d d3 bd fd c1 e4 a0 e7 74 4a 12 0f db 64 00 50 c8 d7 ab e1 c6>
}
2. withdraw request
         {
  cmd: 0,
  reason: 2,
  data: <Buffer 23 7a 81 6f 00 00 00 00 00 00 00 00 00 00 00 00 49 16 04 c0 fd f0 83 47 dd 1f a4 ee 06 2a 82 2a 5d d0 6b 5d 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ... 178 more bytes>
}
-[dapp] successful withdrawal
         { cmd: 0, reason: 4, data: <Buffer 00> }
{
  cmd: 1,
  reason: 1,
  data: <Buffer 47 21 88 78 38 f1 d3 87 4b cd ef 72 37 10 32 b2 a1 26 cb ef 91 cb 9c 5e 50 50 b5 ea f1 87 a3 bb>
}
```
